### PR TITLE
Strict standards error for _getAssetParentId function

### DIFF
--- a/admin/tables/properties.php
+++ b/admin/tables/properties.php
@@ -53,7 +53,7 @@ class TableProperties extends JTable
     /* (non-PHPdoc)
      * @see JTable::_getAssetParentId()
      */
-    protected function _getAssetParentId($table = null, $id = null)
+    protected function _getAssetParentId(JTable $table = null, $id = null)
     {
         $asset = JTable::getInstance('Asset');
         $asset->loadByName('com_jea');


### PR DESCRIPTION
Hello! I'm happy to see that this is finally on github :)

I was testing latest version and got an error in the property form when editing it with error_reporting enabled:

![asset-id](https://cloud.githubusercontent.com/assets/1119272/11099426/9c668fa2-88ab-11e5-9919-eedd1c8ed7a6.png)

I saw that this was also reported in:
http://jea.sphilip.com/forum/viewtopic.php?id=39358

So here is the fix. Are you actively maintaining this then?
